### PR TITLE
add rotes for rejeito, historico, radionuclideo, rejeito_material, re…

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -79,21 +79,23 @@ model Radionclideos {
 }
 
 model RejeitoRadionuclideo {
-  rejeito_id        String @id @default(auto()) @map("_id") @db.ObjectId
-  radionuclideo_id      String @unique
-  atividade_especifica_bq Float
+  id   String @id @default(auto()) @map("_id") @db.ObjectId
+  rejeito_id        String
+  radionuclideo_id      String
+  concentracao_atividade Float
   data_medicao   DateTime
 }
 
 model RejeitoMaterial {
-  rejeito_id        String @id @default(auto()) @map("_id") @db.ObjectId
-  radionuclideo_id      String @unique
+  id   String @id @default(auto()) @map("_id") @db.ObjectId
+  rejeito_id        String
+  material_id      String
   percentual   Float
 }
 
 model HistoricoRejeito {
   id        String @id @default(auto()) @map("_id") @db.ObjectId
-  rejeito_id      String @unique
+  rejeito_id      String
   data_modificacao   DateTime
   tipo_modificacao   String
   descricao   String

--- a/server.js
+++ b/server.js
@@ -7,6 +7,12 @@ import categoriaRoutes from './src/routes/categoria.routes.js';
 import materialRoutes from './src/routes/material.routes.js';
 import statusRoutes from './src/routes/status.routes.js';
 import localRoutes from './src/routes/local.routes.js';
+import radionuclideoRoutes from './src/routes/radionuclideo.routes.js';
+import rejeitoMaterialRoutes from './src/routes/rejeito_material.routes.js';
+import rejeitoRadionuclideoRoutes from './src/routes/rejeito_radionuclideo.routes.js';
+import historicoRoutes from './src/routes/historico.routes.js';
+import rejeitoRoutes from './src/routes/rejeito.routes.js';
+
 
 
 
@@ -20,6 +26,14 @@ app.use('/api/categorias', categoriaRoutes)
 app.use('/api/materiais', materialRoutes)
 app.use('/api/status', statusRoutes)
 app.use('/api/locais', localRoutes)
+app.use('/api/radionuclideos', radionuclideoRoutes)
+app.use('/api/rejeito_material', rejeitoMaterialRoutes)
+app.use('/api/rejeito_radionuclideo', rejeitoRadionuclideoRoutes)
+app.use('/api/historico', historicoRoutes)
+app.use('/api/rejeito', rejeitoRoutes)
+
+
+
 
 
 app.post('/rejeito', async(req, res) => {

--- a/src/controllers/historico.controller.js
+++ b/src/controllers/historico.controller.js
@@ -1,0 +1,71 @@
+import prisma from '../database/prismaClient.js';
+
+// --- CREATE ---
+export const createHistorico = async (req, res) => {
+  try {
+    const { rejeito_id, data_modificacao, tipo_modificacao, descricao, usuario_responsavel } = req.body;
+    const newHistorico = await prisma.historicoRejeito.create({
+      data: { rejeito_id, data_modificacao, tipo_modificacao, descricao, usuario_responsavel }
+    });
+    res.status(201).json(newHistorico);
+  } catch (error) {
+    res.status(500).json({ error: 'Não foi possível criar o historico.' });
+  }
+};
+
+// --- READ ---
+export const getAllHistoricos = async (req, res) => {
+  try {
+    // Uma forma mais segura de verificar se há query params
+    const hasQueryParams = Object.keys(req.query).length > 0;
+    let historicos;
+
+    if (hasQueryParams) {
+      historicos = await prisma.historicoRejeito.findMany({
+        where: {
+          id: req.query.id,
+          rejeito_id: req.query.rejeito_id,
+          data_modificacao: req.query.data_modificacao,
+          tipo_modificacao: req.query.tipo_modificacao,
+          descricao: req.query.descricao,
+          usuario_responsavel: req.query.usuario_responsavel,
+        }
+      });
+    } else {
+      historicos = await prisma.historicoRejeito.findMany();
+    }
+    res.status(200).json(historicos);
+  } catch (error) {
+    res.status(500).json({ error: 'Não foi possível buscar o historico de rejeitos.' });
+  }
+};
+
+// --- UPDATE ---
+export const updateHistorico = async (req, res) => {
+  try {
+    const { id } = req.params;
+    const { rejeito_id, data_modificacao, tipo_modificacao, descricao, usuario_responsavel } = req.body;
+    
+    const updateHistorico = await prisma.historicoRejeito.update({
+      where: { id: id },
+      data: { rejeito_id, data_modificacao, tipo_modificacao, descricao, usuario_responsavel}
+    });
+    // É uma boa prática retornar o objeto atualizado
+    res.status(200).json(updateHistorico); 
+  } catch (error) {
+    res.status(500).json({ error: `Não foi possível atualizar o historico ${req.params.id}.` });
+  }
+};
+
+// --- DELETE ---
+export const deleteHistorico = async (req, res) => {
+  try {
+    const { id } = req.params;
+    await prisma.historicoRejeito.delete({
+      where: { id: id }
+    });
+    res.status(200).json({ message: 'Historico deletado com sucesso' });
+  } catch (error) {
+    res.status(500).json({ error: `Não foi possível deletar o historico do rejeito ${req.params.id}.` });
+  }
+};

--- a/src/controllers/radionuclideo.controller.js
+++ b/src/controllers/radionuclideo.controller.js
@@ -1,0 +1,70 @@
+import prisma from '../database/prismaClient.js';
+
+// --- CREATE ---
+export const createRadionuclideo = async (req, res) => {
+  try {
+    const { simbolo, nome_comum, meia_vida_dias, descricao } = req.body;
+    const newRadionuclideo = await prisma.radionclideos.create({
+      data: { simbolo, nome_comum, meia_vida_dias, descricao }
+    });
+    res.status(201).json(newRadionuclideo);
+  } catch (error) {
+    res.status(500).json({ error: 'Não foi possível criar o radionuclideo.' });
+  }
+};
+
+// --- READ ---
+export const getAllRadionuclideos = async (req, res) => {
+  try {
+    // Uma forma mais segura de verificar se há query params
+    const hasQueryParams = Object.keys(req.query).length > 0;
+    let radionuclideos;
+
+    if (hasQueryParams) {
+      radionuclideos = await prisma.radionclideos.findMany({
+        where: {
+          id: req.query.id,
+          simbolo: req.query.simbolo,
+          nome_comum: req.query.nome_comum,
+          meia_vida_dias: req.query.meia_vida_dias,
+          descricao: req.query.descricao
+        }
+      });
+    } else {
+      radionuclideos = await prisma.radionclideos.findMany();
+    }
+    res.status(200).json(radionuclideos);
+  } catch (error) {
+    res.status(500).json({ error: 'Não foi possível buscar os radionuclideos.' });
+  }
+};
+
+// --- UPDATE ---
+export const updateRadionuclideo = async (req, res) => {
+  try {
+    const { id } = req.params;
+    const { simbolo, nome_comum, meia_vida_dias, descricao } = req.body;
+    
+    const updateRadionuclideo = await prisma.radionclideos.update({
+      where: { id: id },
+      data: { simbolo, nome_comum, meia_vida_dias, descricao }
+    });
+    // É uma boa prática retornar o objeto atualizado
+    res.status(200).json(updateRadionuclideo); 
+  } catch (error) {
+    res.status(500).json({ error: `Não foi possível atualizar o radionuclideo ${req.params.id}.` });
+  }
+};
+
+// --- DELETE ---
+export const deleteRadionuclideo = async (req, res) => {
+  try {
+    const { id } = req.params;
+    await prisma.radionclideos.delete({
+      where: { id: id }
+    });
+    res.status(200).json({ message: 'Radionuclideo deletado com sucesso' });
+  } catch (error) {
+    res.status(500).json({ error: `Não foi possível deletar o radionuclideo ${req.params.id}.` });
+  }
+};

--- a/src/controllers/rejeito.controller.js
+++ b/src/controllers/rejeito.controller.js
@@ -1,0 +1,95 @@
+import prisma from '../database/prismaClient.js';
+
+// --- CREATE ---
+export const createRejeito = async (req, res) => {
+  try {
+    const { codigo_interno, descricao, categoria_id, blindagem_id, 
+      peso_bruto_kg, peso_blindagem_kg, peso_liquido_kg, dimensoes_externas_cm, 
+      dimensoes_internas_cm, atividade_total_bq, data_medicao_total, data_recebimento, 
+      data_liberacao, status_id, local_armazenamento_id } = req.body;
+
+    const newRejeito = await prisma.rejeito.create({
+      data: { codigo_interno, descricao, categoria_id, blindagem_id, 
+      peso_bruto_kg, peso_blindagem_kg, peso_liquido_kg, dimensoes_externas_cm, 
+      dimensoes_internas_cm, atividade_total_bq, data_medicao_total, data_recebimento, 
+      data_liberacao, status_id, local_armazenamento_id }
+    });
+
+    res.status(201).json(newRejeito);
+  } catch (error) {
+    res.status(500).json({ error: 'Não foi possível criar o rejeito.' });
+  }
+};
+
+// --- READ ---
+export const getAllRejeitos = async (req, res) => {
+  try {
+    // Uma forma mais segura de verificar se há query params
+    const hasQueryParams = Object.keys(req.query).length > 0;
+    let rejeitos;
+
+    if (hasQueryParams) {
+      rejeitos = await prisma.rejeito.findMany({
+        where: {
+          id: req.query.id,
+          codigo_interno: req.query.codigo_interno, 
+          descricao: req.query.descricao, 
+          categoria_id: req.query.categoria_id, 
+          blindagem_id: req.query.blindagem_id, 
+          peso_bruto_kg: req.query.peso_bruto_kg, 
+          peso_blindagem_kg: req.query.peso_blindagem_kg, 
+          peso_liquido_kg: req.query.peso_liquido_kg, 
+          dimensoes_externas_cm: req.query.dimensoes_externas_cm, 
+          dimensoes_internas_cm: req.query.dimensoes_internas_cm, 
+          atividade_total_bq: req.query.atividade_total_bq, 
+          data_medicao_total: req.query.data_medicao_total, 
+          data_recebimento: req.query.data_recebimento, 
+          data_liberacao: req.query.data_liberacao, 
+          status_id: req.query.status_id, 
+          local_armazenamento_id: req.query.local_armazenamento_id
+        }
+      });
+    } else {
+      rejeitos = await prisma.rejeito.findMany();
+    }
+    res.status(200).json(rejeitos);
+  } catch (error) {
+    res.status(500).json({ error: 'Não foi possível buscar os rejeitos.' });
+  }
+};
+
+// --- UPDATE ---
+export const updateRejeito = async (req, res) => {
+  try {
+    const { id } = req.params;
+    const {  codigo_interno, descricao, categoria_id, blindagem_id, 
+      peso_bruto_kg, peso_blindagem_kg, peso_liquido_kg, dimensoes_externas_cm, 
+      dimensoes_internas_cm, atividade_total_bq, data_medicao_total, data_recebimento, 
+      data_liberacao, status_id, local_armazenamento_id } = req.body;
+    
+    const updateRejeito = await prisma.rejeito.update({
+      where: { id: id },
+      data: {  codigo_interno, descricao, categoria_id, blindagem_id, 
+      peso_bruto_kg, peso_blindagem_kg, peso_liquido_kg, dimensoes_externas_cm, 
+      dimensoes_internas_cm, atividade_total_bq, data_medicao_total, data_recebimento, 
+      data_liberacao, status_id, local_armazenamento_id }
+    });
+    // É uma boa prática retornar o objeto atualizado
+    res.status(200).json(updateRejeito); 
+  } catch (error) {
+    res.status(500).json({ error: `Não foi possível atualizar o rejeito ${req.params.id}.` });
+  }
+};
+
+// --- DELETE ---
+export const deleteRejeito = async (req, res) => {
+  try {
+    const { id } = req.params;
+    await prisma.rejeito.delete({
+      where: { id: id }
+    });
+    res.status(200).json({ message: 'Rejeito deletado com sucesso' });
+  } catch (error) {
+    res.status(500).json({ error: `Não foi possível deletar o rejeito ${req.params.id}.` });
+  }
+};

--- a/src/controllers/rejeito_material.controller.js
+++ b/src/controllers/rejeito_material.controller.js
@@ -1,0 +1,69 @@
+import prisma from '../database/prismaClient.js';
+
+// --- CREATE ---
+export const createRejeitoMaterial = async (req, res) => {
+  try {
+    const { rejeito_id, material_id, percentual } = req.body;
+    const newRejeitoMaterial = await prisma.rejeitoMaterial.create({
+      data: { rejeito_id, material_id, percentual }
+    });
+    res.status(201).json(newRejeitoMaterial);
+  } catch (error) {
+    res.status(500).json({ error: 'Não foi possível criar o material de rejeito.' });
+  }
+};
+
+// --- READ ---
+export const getAllRejeitosMateriais = async (req, res) => {
+  try {
+    // Uma forma mais segura de verificar se há query params
+    const hasQueryParams = Object.keys(req.query).length > 0;
+    let rejeitosMateriais;
+
+    if (hasQueryParams) {
+      rejeitosMateriais = await prisma.rejeitoMaterial.findMany({
+        where: {
+          id: req.query.id,
+          rejeito_id: req.query.rejeito_id,
+          material_id: req.query.material_id,
+          percentual: req.query.percentual,
+        }
+      });
+    } else {
+      rejeitosMateriais = await prisma.rejeitoMaterial.findMany();
+    }
+    res.status(200).json(rejeitosMateriais);
+  } catch (error) {
+    res.status(500).json({ error: 'Não foi possível buscar os materiais de rejeito.' });
+  }
+};
+
+// --- UPDATE ---
+export const updateRejeitoMaterial = async (req, res) => {
+  try {
+    const { id } = req.params;
+    const { rejeito_id, material_id, percentual } = req.body;
+    
+    const updateRejeitoMaterial = await prisma.rejeitoMaterial.update({
+      where: { id: id },
+      data: { rejeito_id, material_id, percentual  }
+    });
+    // É uma boa prática retornar o objeto atualizado
+    res.status(200).json(updateRejeitoMaterial); 
+  } catch (error) {
+    res.status(500).json({ error: `Não foi possível atualizar o material de rejeito ${req.params.id}.` });
+  }
+};
+
+// --- DELETE ---
+export const deleteRejeitoMaterial = async (req, res) => {
+  try {
+    const { id } = req.params;
+    await prisma.rejeitoMaterial.delete({
+      where: { id: id }
+    });
+    res.status(200).json({ message: 'Material do Rejeito deletada com sucesso' });
+  } catch (error) {
+    res.status(500).json({ error: `Não foi possível deletar a blindagem ${req.params.id}.` });
+  }
+};

--- a/src/controllers/rejeito_radionuclideo.controller.js
+++ b/src/controllers/rejeito_radionuclideo.controller.js
@@ -1,0 +1,71 @@
+import prisma from '../database/prismaClient.js';
+
+// --- CREATE ---
+export const createRejeitoRadionuclideo  = async (req, res) => {
+  try {
+    const { rejeito_id, radionuclideo_id, concentracao_atividade, data_medicao } = req.body;
+    const newRejeitoRadionuclideo = await prisma.rejeitoRadionuclideo.create({
+      data: { rejeito_id, radionuclideo_id, concentracao_atividade, data_medicao}
+    });
+    res.status(201).json(newRejeitoRadionuclideo);
+  } catch (error) {
+    res.status(500).json({ error: 'Não foi possível criar o novo rejeito radionuclideo.' });
+  }
+};
+
+// --- READ ---
+export const getAllRejeitosRadionclideos = async (req, res) => {
+  try {
+    // Uma forma mais segura de verificar se há query params
+    const hasQueryParams = Object.keys(req.query).length > 0;
+    let rejeitos_radionuclideos;
+
+    if (hasQueryParams) {
+      rejeitos_radionuclideos = await prisma.rejeitoRadionuclideo.findMany({
+        where: {
+          id: req.query.id,
+          rejeito_id: req.query.rejeito_id,
+          radionuclideo_id: req.query.radionuclideo_id,
+          concentracao_atividade: req.query.concentracao_atividade,
+          data_medicao: req.query.data_medicao,
+
+        }
+      });
+    } else {
+      rejeitos_radionuclideos = await prisma.rejeitoRadionuclideo.findMany();
+    }
+    res.status(200).json(rejeitos_radionuclideos);
+  } catch (error) {
+    res.status(500).json({ error: 'Não foi possível buscar os rejeitos radionuclideos.' });
+  }
+};
+
+// --- UPDATE ---
+export const updateRejeitoRadionuclideo = async (req, res) => {
+  try {
+    const { id } = req.params;
+    const { rejeito_id, radionuclideo_id, concentracao_atividade, data_medicao } = req.body;
+    
+    const updateRejeitoRadionuclideo = await prisma.rejeitoRadionuclideo.update({
+      where: { id: id },
+      data: { rejeito_id, radionuclideo_id, concentracao_atividade, data_medicao }
+    });
+    // É uma boa prática retornar o objeto atualizado
+    res.status(200).json(updateRejeitoRadionuclideo); 
+  } catch (error) {
+    res.status(500).json({ error: `Não foi possível atualizar o rejeito radionuclideo ${req.params.id}.` });
+  }
+};
+
+// --- DELETE ---
+export const deleteRejeitoRadionuclideo = async (req, res) => {
+  try {
+    const { id } = req.params;
+    await prisma.rejeitoRadionuclideo.delete({
+      where: { id: id }
+    });
+    res.status(200).json({ message: 'Rejeito radionuclideo deletada com sucesso' });
+  } catch (error) {
+    res.status(500).json({ error: `Não foi possível deletar o rejeito radionuclideo ${req.params.id}.` });
+  }
+};

--- a/src/routes/historico.routes.js
+++ b/src/routes/historico.routes.js
@@ -1,0 +1,11 @@
+import { Router } from 'express';
+import { createHistorico, getAllHistoricos, updateHistorico, deleteHistorico } from '../controllers/historico.controller.js';
+
+const router = Router();
+
+router.post('/', createHistorico);
+router.get('/', getAllHistoricos);
+router.put('/:id', updateHistorico);
+router.delete('/:id', deleteHistorico);
+
+export default router;

--- a/src/routes/radionuclideo.routes.js
+++ b/src/routes/radionuclideo.routes.js
@@ -1,0 +1,11 @@
+import { Router } from 'express';
+import { createRadionuclideo, getAllRadionuclideos, updateRadionuclideo, deleteRadionuclideo } from '../controllers/radionuclideo.controller.js';
+
+const router = Router();
+
+router.post('/', createRadionuclideo);
+router.get('/', getAllRadionuclideos);
+router.put('/:id', updateRadionuclideo);
+router.delete('/:id', deleteRadionuclideo);
+
+export default router;

--- a/src/routes/rejeito.routes.js
+++ b/src/routes/rejeito.routes.js
@@ -1,0 +1,11 @@
+import { Router } from 'express';
+import { createRejeito, getAllRejeitos, updateRejeito, deleteRejeito } from '../controllers/rejeito.controller.js';
+
+const router = Router();
+
+router.post('/', createRejeito);
+router.get('/', getAllRejeitos);
+router.put('/:id', updateRejeito);
+router.delete('/:id', deleteRejeito);
+
+export default router;

--- a/src/routes/rejeito_material.routes.js
+++ b/src/routes/rejeito_material.routes.js
@@ -1,0 +1,11 @@
+import { Router } from 'express';
+import { createRejeitoMaterial, getAllRejeitosMateriais, updateRejeitoMaterial, deleteRejeitoMaterial } from '../controllers/rejeito_material.controller.js';
+
+const router = Router();
+
+router.post('/', createRejeitoMaterial);
+router.get('/', getAllRejeitosMateriais);
+router.put('/:id', updateRejeitoMaterial);
+router.delete('/:id', deleteRejeitoMaterial);
+
+export default router;

--- a/src/routes/rejeito_radionuclideo.routes.js
+++ b/src/routes/rejeito_radionuclideo.routes.js
@@ -1,0 +1,11 @@
+import { Router } from 'express';
+import { createRejeitoRadionuclideo, getAllRejeitosRadionclideos, updateRejeitoRadionuclideo, deleteRejeitoRadionuclideo } from '../controllers/rejeito_radionuclideo.controller.js';
+
+const router = Router();
+
+router.post('/', createRejeitoRadionuclideo);
+router.get('/', getAllRejeitosRadionclideos);
+router.put('/:id', updateRejeitoRadionuclideo);
+router.delete('/:id', deleteRejeitoRadionuclideo);
+
+export default router;


### PR DESCRIPTION
Criadas rotas adicionais para chamadas API. 
- Rejeito
- Historico
- Radionuclideo
- Material dos Rejeitos
- Radionuclideos dos Rejeitos 

Também foi necessário fazer adaptações no banco de dados, demonstrado no esquema abaixo: 
<img width="1438" height="1380" alt="Banco CERER" src="https://github.com/user-attachments/assets/6290d701-4205-4399-bc3c-241ee2a355ac" />
